### PR TITLE
Add support for input of array of strings, with textarea having each line as separate entry in array

### DIFF
--- a/lib/talon/form.ex
+++ b/lib/talon/form.ex
@@ -53,6 +53,23 @@ defmodule Talon.Form do
     text_input new_f, field, opts
   end
 
+  defp build_input({a, f}, field, {:array, :string}, opts) do
+    source = f.source
+    resource = source.data
+
+    value = if f.params["#{field}"] != [] do
+              f.params["#{field}"]
+            else
+              Enum.join(Map.get(source.data, field) || [], "\n")
+            end
+
+    opts = opts
+            |> Keyword.put(:value, value)
+            |> Keyword.put(:placeholder, "value1\nvalue2...")
+
+    textarea f, field, opts
+  end
+
   defp build_input({_a, _f}, field, type, _opts) do
     IO.puts "build_input unknow #{inspect type} for #{inspect field}"
     "unknown type"


### PR DESCRIPTION
I needed to have an input for array of strings. Figured the simplest way to do it for now is to have textarea
where each entry is a separate line.

In order to update the field with one more entry you need to add new line to textarea, for example if a model has 3 values in array: value1, value2, value3, the rendered textarea will have the following value:

value1
value2
value3

To add / remove / change entries you just change appropriate lines.

In order for this to work, the corresponding model is responsible of casting fields of type {:array, :string} from string to array in it's changeset/2 function.