### PR TITLE
Generate Phx using the correct Phoenix 1.3 folder structure

### DIFF
--- a/lib/mix/talon.ex
+++ b/lib/mix/talon.ex
@@ -161,7 +161,7 @@ defmodule Mix.Talon do
   def prompt_project_structure(binding) do
     Mix.shell.info [
       "Cannot automatically detect the project structure!\n",
-      "1. Use phx 1.3 structure (lib/#{binding.base}/web)\n",
+      "1. Use phx 1.3 structure (lib/#{binding.base}_web)\n",
       "2. Use phoenix structure (web)\n",
       "3. Abort\n",
     ]
@@ -212,7 +212,7 @@ defmodule Mix.Talon do
   def web_path(opts \\ []) do
     path =
       case detect_project_structure() do
-        :phx -> Path.join ["lib", otp_app_path(), "web"]
+        :phx -> Path.join ["lib", otp_app_path() <> "_web"]
         _    -> "web"
       end
 
@@ -266,6 +266,10 @@ defmodule Mix.Talon do
   @spec web_namespace(:phx | :phoneix) :: String.t
   def web_namespace(:phx), do: "Web."
   def web_namespace(:phoenix), do: ""
+
+  @spec web_base(String.t, :phx | :phoenix) :: String.t
+  def web_base(base, :phx), do: base <> "Web"
+  def web_base(base, :phoenix), do: base
 
   @spec web_module(String.t | nil) :: String.t
   def web_module("Web."), do: "Web"

--- a/lib/mix/talon.ex
+++ b/lib/mix/talon.ex
@@ -267,6 +267,10 @@ defmodule Mix.Talon do
   def web_namespace(:phx), do: "Web."
   def web_namespace(:phoenix), do: ""
 
+  @spec controller_namespace(:phx | :phoenix) :: String.t
+  def controller_namespace(:phx), do: ""
+  def controller_namespace(:phoenix), do: ".Web"
+
   @spec web_base(String.t, :phx | :phoenix) :: String.t
   def web_base(base, :phx), do: base <> "Web"
   def web_base(base, :phoenix), do: base

--- a/lib/mix/tasks/talon.gen.components.ex
+++ b/lib/mix/tasks/talon.gen.components.ex
@@ -100,9 +100,16 @@ defmodule Mix.Tasks.Talon.Gen.Components do
       |> Path.wildcard
       |> Enum.map(&Path.basename/1)
 
-    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, theme_name: config.theme_name,
-      theme_module: config.theme_module, web_namespace: config.web_namespace,
-      view_opts: config.view_opts, concern_path: config.concern_path, concern: config.concern]
+    binding = Kernel.binding() ++ [
+      base: config.base,
+      web_base: config.web_base,
+      theme_name: config.theme_name,
+      theme_module: config.theme_module,
+      web_namespace: config.web_namespace,
+      view_opts: config.view_opts,
+      concern_path: config.concern_path,
+      concern: config.concern
+    ]
 
     infos =
       file_names

--- a/lib/mix/tasks/talon.gen.components.ex
+++ b/lib/mix/tasks/talon.gen.components.ex
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Talon.Gen.Components do
       |> Path.wildcard
       |> Enum.map(&Path.basename/1)
 
-    binding = Kernel.binding() ++ [base: config.base, theme_name: config.theme_name,
+    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, theme_name: config.theme_name,
       theme_module: config.theme_module, web_namespace: config.web_namespace,
       view_opts: config.view_opts, concern_path: config.concern_path, concern: config.concern]
 
@@ -161,6 +161,7 @@ defmodule Mix.Tasks.Talon.Gen.Components do
       web_namespace: web_namespace(proj_struct),
       boilerplate: bin_opts[:boilerplate] || Config.boilerplate() || true,
       base: base,
+      web_base: web_base(base, proj_struct),
     }
   end
 

--- a/lib/mix/tasks/talon.gen.concern.ex
+++ b/lib/mix/tasks/talon.gen.concern.ex
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.Talon.Gen.Concern do
     layout = Module.concat([config.base, config.concern, config.theme_module,
       web_module, LayoutView])
     layout = ~s/{#{inspect layout}, "app.html"}/
-    binding = Kernel.binding() ++ [base: config.base, concern: config.concern,
+    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, concern: config.concern,
       boilerplate: config[:boilerplate], web_namespace: config.web_namespace,
       layout: layout, web_module: web_module]
     target_path = Path.join([config.root_path, "controllers", config.path_prefix])
@@ -169,6 +169,7 @@ defmodule Mix.Tasks.Talon.Gen.Concern do
       concern_path: concern_path(concern),
       boilerplate: bin_opts[:boilerplate] || Config.boilerplate() || true,
       base: base,
+      web_base: web_base(base, proj_struct),
       app: app
     }
   end

--- a/lib/mix/tasks/talon.gen.concern.ex
+++ b/lib/mix/tasks/talon.gen.concern.ex
@@ -92,9 +92,16 @@ defmodule Mix.Tasks.Talon.Gen.Concern do
     layout = Module.concat([config.base, config.concern, config.theme_module,
       web_module, LayoutView])
     layout = ~s/{#{inspect layout}, "app.html"}/
-    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, concern: config.concern,
-      boilerplate: config[:boilerplate], web_namespace: config.web_namespace,
-      layout: layout, web_module: web_module]
+    binding = Kernel.binding() ++ [
+      base: config.base,
+      web_base: config.web_base,
+      concern: config.concern,
+      boilerplate: config[:boilerplate],
+      web_namespace: config.web_namespace,
+      controller_namespace: config.controller_namespace,
+      layout: layout,
+      web_module: web_module
+    ]
     target_path = Path.join([config.root_path, "controllers", config.path_prefix])
     unless config.dry_run do
       File.mkdir_p! target_path
@@ -165,6 +172,7 @@ defmodule Mix.Tasks.Talon.Gen.Concern do
       theme_module: theme_module,
       project_structure: proj_struct,
       web_namespace: web_namespace(proj_struct),
+      controller_namespace: controller_namespace(proj_struct),
       concern: concern,
       concern_path: concern_path(concern),
       boilerplate: bin_opts[:boilerplate] || Config.boilerplate() || true,

--- a/lib/mix/tasks/talon.gen.resource.ex
+++ b/lib/mix/tasks/talon.gen.resource.ex
@@ -87,7 +87,7 @@ defmodule Mix.Tasks.Talon.Gen.Resource do
     unless config.dry_run do
       # Enum.each config.themes, fn theme ->
         theme = config.target_name
-        binding = config.binding ++ [base: config[:base], resource: config.resource,
+        binding = config.binding ++ [base: config[:base], web_base: config.web_base, resource: config.resource,
           theme_module: theme_module_name(theme), theme_name: theme, view_opts: config.view_opts,
           web_namespace: config.web_namespace, concern: config.concern,
           concern_path: config.concern_path]
@@ -193,6 +193,7 @@ defmodule Mix.Tasks.Talon.Gen.Resource do
       project_structure: proj_struct,
       boilerplate: bin_opts[:boilerplate] || Application.get_env(:talon, :boilerplate, true),
       base: base,
+      web_base: web_base(base, proj_struct),
     }
     # |> IO.inspect(label: "contfig")
   end

--- a/lib/mix/tasks/talon.gen.resource.ex
+++ b/lib/mix/tasks/talon.gen.resource.ex
@@ -87,10 +87,17 @@ defmodule Mix.Tasks.Talon.Gen.Resource do
     unless config.dry_run do
       # Enum.each config.themes, fn theme ->
         theme = config.target_name
-        binding = config.binding ++ [base: config[:base], web_base: config.web_base, resource: config.resource,
-          theme_module: theme_module_name(theme), theme_name: theme, view_opts: config.view_opts,
-          web_namespace: config.web_namespace, concern: config.concern,
-          concern_path: config.concern_path]
+        binding = config.binding ++ [
+          base: config[:base],
+          web_base: config.web_base,
+          resource: config.resource,
+          theme_module: theme_module_name(theme),
+          theme_name: theme,
+          view_opts: config.view_opts,
+          web_namespace: config.web_namespace,
+          concern: config.concern,
+          concern_path: config.concern_path
+        ]
         target_path = Path.join([config.root_path, "views", config.path_prefix,
             config.concern_path, theme])
         copy_from paths(),

--- a/lib/mix/tasks/talon.gen.theme.ex
+++ b/lib/mix/tasks/talon.gen.theme.ex
@@ -174,7 +174,7 @@ defmodule Mix.Tasks.Talon.Gen.Theme do
   defp gen_components(config), do: config
 
   defp gen_layout_view(%{layouts: true} = config) do
-    binding = Kernel.binding() ++ [base: config.base, target_name: config.target_name,
+    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, target_name: config.target_name,
       target_module: config.target_module, web_namespace: config.web_namespace,
       view_opts: config.view_opts, concern: config.concern]
     theme = config.theme
@@ -213,7 +213,7 @@ defmodule Mix.Tasks.Talon.Gen.Theme do
   defp gen_layout_templates(config), do: config
 
   defp gen_generators(%{generators: true} = config) do
-    binding = Kernel.binding() ++ [base: config.base, target_name: config.target_name,
+    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, target_name: config.target_name,
       target_module: config.target_module, web_namespace: config.web_namespace, concern: config.concern]
     theme = config.theme
     template_path = Path.join([config.root_path, "templates", config.path_prefix,
@@ -254,7 +254,7 @@ defmodule Mix.Tasks.Talon.Gen.Theme do
   def gen_dashboard(config), do: config
 
   defp gen_dashboard_view(%{dashboard: true} = config) do
-    binding = Kernel.binding() ++ [base: config.base, target_name: config.target_name,
+    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, target_name: config.target_name,
       target_module: config.target_module, web_namespace: config.web_namespace,
       view_opts: config.view_opts, concern: config.concern, page: "Dashboard"]
 
@@ -453,6 +453,7 @@ defmodule Mix.Tasks.Talon.Gen.Theme do
         binding: binding,
         boilerplate: bin_opts[:boilerplate] || Application.get_env(:talon, :boilerplate, true),
         base: base,
+        web_base: web_base(base, proj_struct),
       })
     |> set_config_onlys(bin_opts)
   end

--- a/lib/mix/tasks/talon.gen.theme.ex
+++ b/lib/mix/tasks/talon.gen.theme.ex
@@ -174,9 +174,16 @@ defmodule Mix.Tasks.Talon.Gen.Theme do
   defp gen_components(config), do: config
 
   defp gen_layout_view(%{layouts: true} = config) do
-    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, target_name: config.target_name,
-      target_module: config.target_module, web_namespace: config.web_namespace,
-      view_opts: config.view_opts, concern: config.concern]
+    binding = Kernel.binding() ++ [
+      base: config.base,
+      web_base: config.web_base,
+      target_name: config.target_name,
+      target_module: config.target_module,
+      web_namespace: config.web_namespace,
+      controller_namespace: config.controller_namespace,
+      view_opts: config.view_opts,
+      concern: config.concern
+    ]
     theme = config.theme
     view_path = Path.join([config.root_path, "views", config.path_prefix,
       config.concern_path, config.target_name])
@@ -213,8 +220,15 @@ defmodule Mix.Tasks.Talon.Gen.Theme do
   defp gen_layout_templates(config), do: config
 
   defp gen_generators(%{generators: true} = config) do
-    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, target_name: config.target_name,
-      target_module: config.target_module, web_namespace: config.web_namespace, concern: config.concern]
+    binding = Kernel.binding() ++ [
+      base: config.base,
+      web_base: config.web_base,
+      target_name: config.target_name,
+      target_module: config.target_module,
+      web_namespace: config.web_namespace,
+      controller_namespace: config.controller_namespace,
+      concern: config.concern
+    ]
     theme = config.theme
     template_path = Path.join([config.root_path, "templates", config.path_prefix,
       config.concern_path, config.target_name, "generators"])
@@ -254,9 +268,17 @@ defmodule Mix.Tasks.Talon.Gen.Theme do
   def gen_dashboard(config), do: config
 
   defp gen_dashboard_view(%{dashboard: true} = config) do
-    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, target_name: config.target_name,
-      target_module: config.target_module, web_namespace: config.web_namespace,
-      view_opts: config.view_opts, concern: config.concern, page: "Dashboard"]
+    binding = Kernel.binding() ++ [
+      base: config.base,
+      web_base: config.web_base,
+      target_name: config.target_name,
+      target_module: config.target_module,
+      web_namespace: config.web_namespace,
+      controller_namespace: config.controller_namespace,
+      view_opts: config.view_opts,
+      concern: config.concern,
+      page: "Dashboard"
+    ]
 
     theme = config.theme
     view_path = Path.join([config.root_path, "views", config.path_prefix, config.concern_path, config.target_name])
@@ -449,6 +471,7 @@ defmodule Mix.Tasks.Talon.Gen.Theme do
         dry_run: bin_opts[:dry_run],
         project_structure: proj_struct,
         web_namespace: web_namespace(proj_struct),
+        controller_namespace: controller_namespace(proj_struct),
         view_opts: view_opts,
         binding: binding,
         boilerplate: bin_opts[:boilerplate] || Application.get_env(:talon, :boilerplate, true),

--- a/lib/mix/tasks/talon.new.ex
+++ b/lib/mix/tasks/talon.new.ex
@@ -159,7 +159,7 @@ defmodule Mix.Tasks.Talon.New do
     layout = Module.concat([config.base, config.concern, config.theme_module,
       web_module, LayoutView])
     layout = ~s/{#{layout}, "app.html"}/
-    binding = Kernel.binding() ++ [base: config.base, concern: config.concern,
+    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, concern: config.concern,
       boilerplate: config[:boilerplate], web_namespace: config.web_namespace,
       layout: layout, web_module: web_module]
     target_path = Path.join([config.root_path, "controllers", config.path_prefix])
@@ -180,7 +180,7 @@ defmodule Mix.Tasks.Talon.New do
     layout = Module.concat([config.base, config.concern, config.theme_module,
       web_module, LayoutView])
     layout = ~s/{#{layout}, "app.html"}/  # TODO: DJS handle layout
-    binding = Kernel.binding() ++ [base: config.base, concern: config.concern,
+    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, concern: config.concern,
       boilerplate: config[:boilerplate], web_namespace: config.web_namespace,
       layout: layout, web_module: web_module]
     target_path = Path.join([config.root_path, "controllers", config.path_prefix])
@@ -212,7 +212,7 @@ defmodule Mix.Tasks.Talon.New do
     fname = "talon_web.ex"
     theme = config.theme_name
     binding = Kernel.binding() ++
-      [base: config.base, web_namespace: config.web_namespace, theme: theme,
+      [base: config.base, web_base: config.web_base, web_namespace: config.web_namespace, theme: theme,
         theme_module: Inflex.camelize(theme), root_path: config.root_path,
         path_prefix: config.path_prefix]
     target_path = Path.join config.root_path, config.path_prefix
@@ -228,7 +228,7 @@ defmodule Mix.Tasks.Talon.New do
   def gen_messages(config) do
     fname = "talon_messages.ex"
     binding = Kernel.binding() ++
-      [base: config.base, web_namespace: config.web_namespace]
+      [base: config.base, web_base: config.web_base, web_namespace: config.web_namespace]
     target_path = Path.join config.root_path, config.path_prefix
     unless config.dry_run do
       copy_from paths(),
@@ -360,6 +360,7 @@ defmodule Mix.Tasks.Talon.New do
         binding: binding,
         boilerplate: bin_opts[:boilerplate] || Application.get_env(:talon, :boilerplate, true),
         base: bin_opts[:module] || binding[:base],
+        web_base: web_base(bin_opts[:module] || binding[:base], proj_struct),
       })
   end
 

--- a/lib/mix/tasks/talon.new.ex
+++ b/lib/mix/tasks/talon.new.ex
@@ -294,12 +294,6 @@ defmodule Mix.Tasks.Talon.New do
   end
 
   defp print_route_instructions(config) do
-    namespace =
-      if config.project_structure == :phx do
-        "#{config.base}.Web"
-      else
-        config.base
-      end
     full_concern = Module.concat config.base, config.concern
 
     route_scope = Inflex.underscore(config.concern)
@@ -311,7 +305,7 @@ defmodule Mix.Tasks.Talon.New do
       use Talon.Router
 
       # your app's routes
-      scope "/#{route_scope}", #{namespace} do
+      scope "/#{route_scope}", #{config.web_base} do
         pipe_through :browser
         talon_routes(#{to_s full_concern})
       end

--- a/lib/mix/tasks/talon.new.ex
+++ b/lib/mix/tasks/talon.new.ex
@@ -159,9 +159,16 @@ defmodule Mix.Tasks.Talon.New do
     layout = Module.concat([config.base, config.concern, config.theme_module,
       web_module, LayoutView])
     layout = ~s/{#{layout}, "app.html"}/
-    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, concern: config.concern,
-      boilerplate: config[:boilerplate], web_namespace: config.web_namespace,
-      layout: layout, web_module: web_module]
+    binding = Kernel.binding() ++ [
+      base: config.base,
+      web_base: config.web_base,
+      concern: config.concern,
+      boilerplate: config[:boilerplate],
+      web_namespace: config.web_namespace,
+      controller_namespace: config.controller_namespace,
+      layout: layout,
+      web_module: web_module
+    ]
     target_path = Path.join([config.root_path, "controllers", config.path_prefix])
     unless config.dry_run do
       File.mkdir_p! target_path
@@ -180,9 +187,16 @@ defmodule Mix.Tasks.Talon.New do
     layout = Module.concat([config.base, config.concern, config.theme_module,
       web_module, LayoutView])
     layout = ~s/{#{layout}, "app.html"}/  # TODO: DJS handle layout
-    binding = Kernel.binding() ++ [base: config.base, web_base: config.web_base, concern: config.concern,
-      boilerplate: config[:boilerplate], web_namespace: config.web_namespace,
-      layout: layout, web_module: web_module]
+    binding = Kernel.binding() ++ [
+      base: config.base,
+      web_base: config.web_base,
+      concern: config.concern,
+      boilerplate: config[:boilerplate],
+      web_namespace: config.web_namespace,
+      controller_namespace: config.controller_namespace,
+      layout: layout,
+      web_module: web_module
+    ]
     target_path = Path.join([config.root_path, "controllers", config.path_prefix])
     unless config.dry_run do
       File.mkdir_p! target_path
@@ -211,10 +225,15 @@ defmodule Mix.Tasks.Talon.New do
   def gen_web(config) do
     fname = "talon_web.ex"
     theme = config.theme_name
-    binding = Kernel.binding() ++
-      [base: config.base, web_base: config.web_base, web_namespace: config.web_namespace, theme: theme,
-        theme_module: Inflex.camelize(theme), root_path: config.root_path,
-        path_prefix: config.path_prefix]
+    binding = Kernel.binding() ++ [
+      base: config.base,
+      web_base: config.web_base,
+      web_namespace: config.web_namespace,
+      theme: theme,
+      theme_module: Inflex.camelize(theme),
+      root_path: config.root_path,
+      path_prefix: config.path_prefix
+    ]
     target_path = Path.join config.root_path, config.path_prefix
     unless config.dry_run do
       copy_from paths(),
@@ -227,8 +246,11 @@ defmodule Mix.Tasks.Talon.New do
 
   def gen_messages(config) do
     fname = "talon_messages.ex"
-    binding = Kernel.binding() ++
-      [base: config.base, web_base: config.web_base, web_namespace: config.web_namespace]
+    binding = Kernel.binding() ++ [
+      base: config.base,
+      web_base: config.web_base,
+      web_namespace: config.web_namespace,
+    ]
     target_path = Path.join config.root_path, config.path_prefix
     unless config.dry_run do
       copy_from paths(),
@@ -351,6 +373,7 @@ defmodule Mix.Tasks.Talon.New do
         app_path_name: app_path_name,
         project_structure: proj_struct,
         web_namespace: web_namespace(proj_struct),
+        controller_namespace: controller_namespace(proj_struct),
         binding: binding,
         boilerplate: bin_opts[:boilerplate] || Application.get_env(:talon, :boilerplate, true),
         base: bin_opts[:module] || binding[:base],

--- a/priv/templates/talon.new/config/concern_config.exs
+++ b/priv/templates/talon.new/config/concern_config.exs
@@ -7,8 +7,8 @@ config :<%= config.app %>, <%= config.base %>.<%= config.concern %>,
   root_path: "<%= config.root_path %>",
   path_prefix: "<%= config.path_prefix %>",
   repo: <%= config.base %>.Repo,
-  router: <%= config.base %>.Web.Router,
-  endpoint: <%= config.base %>.Web.Endpoint,
+  router: <%= config.web_base %>.Router,
+  endpoint: <%= config.web_base %>.Endpoint,
   schema_adapter: Talon.Schema.Adapters.Ecto,
   messages_backend: <%= config.base %>.Talon.Messages
 

--- a/priv/templates/talon.new/web/controllers/page_controller.ex
+++ b/priv/templates/talon.new/web/controllers/page_controller.ex
@@ -1,5 +1,5 @@
 defmodule <%= web_base %>.<%= concern %>PageController do
-  use <%= web_base %>, :controller
+  use <%= web_base %><%= controller_namespace %>, :controller
   use Talon.PageController, concern: <%= base %>.<%= concern %>
 
   plug Talon.Plug.LoadConcern, concern: <%= base %>.<%= concern %>, web_namespace: <%= web_module %>

--- a/priv/templates/talon.new/web/controllers/page_controller.ex
+++ b/priv/templates/talon.new/web/controllers/page_controller.ex
@@ -1,5 +1,5 @@
-defmodule <%= base %>.<%= web_namespace %><%= concern %>PageController do
-  use <%= base %>.Web, :controller
+defmodule <%= web_base %>.<%= concern %>PageController do
+  use <%= web_base %>, :controller
   use Talon.PageController, concern: <%= base %>.<%= concern %>
 
   plug Talon.Plug.LoadConcern, concern: <%= base %>.<%= concern %>, web_namespace: <%= web_module %>

--- a/priv/templates/talon.new/web/controllers/resource_controller.ex
+++ b/priv/templates/talon.new/web/controllers/resource_controller.ex
@@ -1,5 +1,5 @@
 defmodule <%= web_base %>.<%= concern %>ResourceController do
-  use <%= web_base %>, :controller
+  use <%= web_base %><%= controller_namespace %>, :controller
   use Talon.Controller, repo: <%= base %>.Repo, concern: <%= base %>.<%= concern %>
 
   plug Talon.Plug.LoadConcern, concern: <%= base %>.<%= concern %>, web_namespace: <%= web_module %>

--- a/priv/templates/talon.new/web/controllers/resource_controller.ex
+++ b/priv/templates/talon.new/web/controllers/resource_controller.ex
@@ -1,5 +1,5 @@
-defmodule <%= base %>.<%= web_namespace %><%= concern %>ResourceController do
-  use <%= base %>.Web, :controller
+defmodule <%= web_base %>.<%= concern %>ResourceController do
+  use <%= web_base %>, :controller
   use Talon.Controller, repo: <%= base %>.Repo, concern: <%= base %>.<%= concern %>
 
   plug Talon.Plug.LoadConcern, concern: <%= base %>.<%= concern %>, web_namespace: <%= web_module %>

--- a/priv/templates/talon.new/web/talon_messages.ex
+++ b/priv/templates/talon.new/web/talon_messages.ex
@@ -12,7 +12,7 @@ defmodule <%= base %>.Talon.Messages do
   """
   @behaviour Talon.Messages
 
-  import <%= base %>.<%= web_namespace %>Gettext
+  import <%= web_base %>.Gettext
 
   # Change this to override the "talon" gettext domain. If you would like
   # the talon message to be part of your projects domain change it to "default"

--- a/priv/templates/talon.new/web/talon_web.ex
+++ b/priv/templates/talon.new/web/talon_web.ex
@@ -31,15 +31,15 @@ defmodule <%= base %>.Talon.Web do
   def resource(_) do
     quote do
       import Ecto.Query
-      import <%= base %>.<%= web_namespace %>Gettext
-      require <%= base %>.<%= web_namespace %>Gettext
+      import <%= web_base %>.Gettext
+      require <%= web_base %>.Gettext
     end
   end
 
   def page(_) do
     quote do
-      import <%= base %>.<%= web_namespace %>Gettext
-      require <%= base %>.<%= web_namespace %>Gettext
+      import <%= web_base %>.Gettext
+      require <%= web_base %>.Gettext
     end
   end
 
@@ -53,8 +53,8 @@ defmodule <%= base %>.Talon.Web do
       import Ecto
       import Ecto.Query
 
-      import <%= base %>.<%= web_namespace %>Router.Helpers
-      import <%= base %>.<%= web_namespace %>Gettext
+      import <%= web_base %>.Router.Helpers
+      import <%= web_base %>.Gettext
     end
   end
 
@@ -72,9 +72,9 @@ defmodule <%= base %>.Talon.Web do
       # Use all HTML functionality (forms, tags, etc)
       use Phoenix.HTML
 
-      import <%= base %>.<%= web_namespace %>Router.Helpers
-      import <%= base %>.<%= web_namespace %>ErrorHelpers
-      import <%= base %>.<%= web_namespace %>Gettext
+      import <%= web_base %>.Router.Helpers
+      import <%= web_base %>.ErrorHelpers
+      import <%= web_base %>.Gettext
     end
   end
 
@@ -92,9 +92,9 @@ defmodule <%= base %>.Talon.Web do
       # Use all HTML functionality (forms, tags, etc)
       use Phoenix.HTML
 
-      import <%= base %>.<%= web_namespace %>Router.Helpers
-      import <%= base %>.<%= web_namespace %>ErrorHelpers
-      import <%= base %>.<%= web_namespace %>Gettext
+      import <%= web_base %>.Router.Helpers
+      import <%= web_base %>.ErrorHelpers
+      import <%= web_base %>.Gettext
     end
   end
 
@@ -111,7 +111,7 @@ defmodule <%= base %>.Talon.Web do
       alias <%= base %>.Repo
       import Ecto
       import Ecto.Query
-      import <%= base %>.<%= web_namespace %>Gettext
+      import <%= web_base %>.Gettext
     end
   end
 

--- a/test/mix/tasks/talon.new_test.exs
+++ b/test/mix/tasks/talon.new_test.exs
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Talon.NewTest do
     test "talon.new", %{parsed: _parsed} do
       Logger.disable(self())
 
-      Application.put_env(:phx_blogger, PhxBlogger.Web.Endpoint,
+      Application.put_env(:phx_blogger, PhxBloggerWeb.Endpoint,
         secret_key_base: String.duplicate("abcdefgh", 8),
         code_reloader: true,
         root: File.cwd!)
@@ -56,20 +56,20 @@ defmodule Mix.Tasks.Talon.NewTest do
         ]
 
         assert_file "lib/phx_blogger/talon/web.ex", [
-          "import PhxBlogger.Web.Router.Helpers",
-          "import PhxBlogger.Web.ErrorHelpers",
-          "import PhxBlogger.Web.Gettext",
+          "import PhxBloggerWeb.Router.Helpers",
+          "import PhxBloggerWeb.ErrorHelpers",
+          "import PhxBloggerWeb.Gettext",
         ]
 
         assert_file "lib/phx_blogger/talon/controllers/admin_resource_controller.ex", [
-          "defmodule PhxBlogger.Web.AdminResourceController do",
-          "use PhxBlogger.Web, :controller",
+          "defmodule PhxBloggerWeb.AdminResourceController do",
+          "use PhxBloggerWeb, :controller",
           "use Talon.Controller, repo: PhxBlogger.Repo, concern: PhxBlogger.Admin"
         ]
 
         assert_file "lib/phx_blogger/talon/controllers/admin_page_controller.ex", [
-          "defmodule PhxBlogger.Web.AdminPageController do",
-          "use PhxBlogger.Web, :controller",
+          "defmodule PhxBloggerWeb.AdminPageController do",
+          "use PhxBloggerWeb, :controller",
           "use Talon.PageController, concern: PhxBlogger.Admin",
           "plug Talon.Plug.LoadConcern",
           "plug Talon.Plug.Theme",
@@ -85,7 +85,7 @@ defmodule Mix.Tasks.Talon.NewTest do
 
         assert_file "lib/phx_blogger/talon/messages.ex", [
           "defmodule PhxBlogger.Talon.Messages do",
-          "import PhxBlogger.Web.Gettext"
+          "import PhxBloggerWeb.Gettext"
         ]
 
         #########


### PR DESCRIPTION
Fix for Issue #90.

The web_base and controller_namespace were added in order to generate the correct namespaces for the two supported Phoenix folder structures.

With this fix, Talon seems to work with the new Phoenix folder structure, but the "talon" folder is added to the "lib/MY_PROJECT/" folder.
I think it will necessary to move it in it own folder in the "lib" directory as "lib/MY_PROJECT_talon".
Do I need to open another Issue to change the folder location?