### PR TITLE
Fix typos

### DIFF
--- a/lib/mix/talon.ex
+++ b/lib/mix/talon.ex
@@ -263,7 +263,7 @@ defmodule Mix.Talon do
       iex> Talon.Mix.web_namespace(:phx)
       "Web."
   """
-  @spec web_namespace(:phx | :phoneix) :: String.t
+  @spec web_namespace(:phx | :phoenix) :: String.t
   def web_namespace(:phx), do: "Web."
   def web_namespace(:phoenix), do: ""
 

--- a/lib/talon/controller.ex
+++ b/lib/talon/controller.ex
@@ -49,7 +49,7 @@ defmodule Talon.Controller do # TODO: rename to ResourceController (DJS)
         case repo.insert(changeset) do
           {:ok, resource} ->
             conn
-            |> put_flash(:success, Talon.Concern.concern(conn).messages_backend().created_succesfully())
+            |> put_flash(:success, Talon.Concern.concern(conn).messages_backend().created_successfully())
             |> redirect(to: Talon.Concern.resource_path(conn, resource, :show))
           {:error, changeset} ->
             render conn, "new.html", changeset: changeset
@@ -64,7 +64,7 @@ defmodule Talon.Controller do # TODO: rename to ResourceController (DJS)
         case repo.update(changeset) do
           {:ok, resource} ->
             conn
-            |> put_flash(:success, Talon.Concern.concern(conn).messages_backend().changed_succesfully())
+            |> put_flash(:success, Talon.Concern.concern(conn).messages_backend().changed_successfully())
             |> redirect(to: Talon.Concern.resource_path(conn, resource, :show))
           {:error, changeset} ->
             render conn, "edit.html", changeset: changeset

--- a/priv/templates/talon.new/web/talon_messages.ex
+++ b/priv/templates/talon.new/web/talon_messages.ex
@@ -23,6 +23,6 @@ defmodule <%= base %>.Talon.Messages do
 
   def are_you_sure_you_want_to_delete_this?, do: dgettext(@domain, "Are you sure you want to delete this?")
   def not_loaded, do: dgettext(@domain, "Not Loaded")
-  def changed_successfully, do: dgettext(@domain, "Changed succesfully")
-  def created_successfully, do: dgettext(@domain, "Created succesfully")
+  def changed_successfully, do: dgettext(@domain, "Changed successfully")
+  def created_successfully, do: dgettext(@domain, "Created successfully")
 end


### PR DESCRIPTION
This branch fixes some typos I encountered while adding support for the new Phoenix 1.3 directory structure.
One of the typo caused errors when saving resources in the Talon admin.